### PR TITLE
Add `TextEncoder` and `TextDecoder`

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,3 +1,5 @@
+const { TextEncoder: _TextEncoder, TextDecoder } = require('bare-encoding')
+
 exports.format = require('bare-format')
 
 exports.formatWithOptions = exports.format.formatWithOptions
@@ -29,3 +31,11 @@ exports.deprecate = function deprecate(fn, msg, code) {
     return Reflect.apply(fn, this, args)
   }
 }
+
+exports.TextEncoder = class TextEncoder extends _TextEncoder {
+  encode(input) {
+    return new Uint8Array(super.encode(input))
+  }
+}
+
+exports.TextDecoder = TextDecoder

--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-const { TextEncoder: _TextEncoder, TextDecoder } = require('bare-encoding')
+const { TextEncoder, TextDecoder } = require('bare-encoding')
 
 exports.format = require('bare-format')
 
@@ -32,11 +32,6 @@ exports.deprecate = function deprecate(fn, msg, code) {
   }
 }
 
-exports.TextEncoder = class TextEncoder extends _TextEncoder {
-  encode(input) {
-    const buffer = super.encode(input)
-    return new Uint8Array(buffer.buffer, buffer.byteOffset, buffer.byteLength)
-  }
-}
+exports.TextEncoder = TextEncoder
 
 exports.TextDecoder = TextDecoder

--- a/index.js
+++ b/index.js
@@ -34,7 +34,8 @@ exports.deprecate = function deprecate(fn, msg, code) {
 
 exports.TextEncoder = class TextEncoder extends _TextEncoder {
   encode(input) {
-    return new Uint8Array(super.encode(input))
+    const buffer = super.encode(input)
+    return new Uint8Array(buffer.buffer, buffer.byteOffset, buffer.byteLength)
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   "homepage": "https://github.com/holepunchto/bare-utils#readme",
   "dependencies": {
     "bare-debug-log": "^2.0.0",
+    "bare-encoding": "^1.0.0",
     "bare-format": "^1.0.0",
     "bare-inspect": "^3.0.0"
   },

--- a/test.js
+++ b/test.js
@@ -23,3 +23,37 @@ test('deprecate', (t) => {
 
   bare()
 })
+
+test('TextEncoder', (t) => {
+  const encoder = new util.TextEncoder()
+
+  t.test('encode', (t) => {
+    t.alike(encoder.encode('123'), new Uint8Array([49, 50, 51]))
+  })
+
+  t.test('encodeInto', (t) => {
+    const dest = new Uint8Array(3)
+
+    const { read, written } = encoder.encodeInto('123', dest)
+
+    t.is(read, 3)
+    t.is(written, 3)
+    t.alike(dest, new Uint8Array([49, 50, 51]))
+  })
+
+  t.test('encoding', (t) => {
+    t.is(encoder.encoding, 'utf-8')
+  })
+})
+
+test('TextDecoder', (t) => {
+  const decoder = new util.TextDecoder()
+
+  t.test('decode', (t) => {
+    t.is(decoder.decode(new Uint8Array([49, 50, 51])), '123')
+  })
+
+  t.test('encoding', (t) => {
+    t.is(decoder.encoding, 'utf-8')
+  })
+})

--- a/test.js
+++ b/test.js
@@ -24,36 +24,6 @@ test('deprecate', (t) => {
   bare()
 })
 
-test('TextEncoder', (t) => {
-  const encoder = new util.TextEncoder()
+test('TextEncoder', (t) => t.ok(util.TextEncoder))
 
-  t.test('encode', (t) => {
-    t.alike(encoder.encode('123'), new Uint8Array([49, 50, 51]))
-  })
-
-  t.test('encodeInto', (t) => {
-    const dest = new Uint8Array(3)
-
-    const { read, written } = encoder.encodeInto('123', dest)
-
-    t.is(read, 3)
-    t.is(written, 3)
-    t.alike(dest, new Uint8Array([49, 50, 51]))
-  })
-
-  t.test('encoding', (t) => {
-    t.is(encoder.encoding, 'utf-8')
-  })
-})
-
-test('TextDecoder', (t) => {
-  const decoder = new util.TextDecoder()
-
-  t.test('decode', (t) => {
-    t.is(decoder.decode(new Uint8Array([49, 50, 51])), '123')
-  })
-
-  t.test('encoding', (t) => {
-    t.is(decoder.encoding, 'utf-8')
-  })
-})
+test('TextDecoder', (t) => t.ok(util.TextDecoder))


### PR DESCRIPTION
I started writing some tests to ensure compat, and `TextEncoder.encode` needed a tweak to pass the test.

From https://encoding.spec.whatwg.org/#dom-textencoder-encode, the step 4 states that the return value should be an `Uint8Array`. `bare-encoding` encode method returns a Buffer, which is an `Uint8Array` (https://github.com/holepunchto/bare-buffer/blob/fb7604068777cbfd765e8693d6aefcd809470c7b/index.js#L14) by inheritance, so, there's space for interpretation I guess.